### PR TITLE
cocoa: Don't report wakeups from other threads via the `WindowProxy` as real events.

### DIFF
--- a/src/cocoa/mod.rs
+++ b/src/cocoa/mod.rs
@@ -30,7 +30,7 @@ use std::str::from_utf8;
 use std::sync::Mutex;
 use std::ascii::AsciiExt;
 
-use events::Event::{MouseInput, MouseMoved, ReceivedCharacter, KeyboardInput, MouseWheel};
+use events::Event::{Awakened, MouseInput, MouseMoved, ReceivedCharacter, KeyboardInput, MouseWheel};
 use events::ElementState::{Pressed, Released};
 use events::MouseButton;
 use events;
@@ -333,6 +333,8 @@ impl<'a> Iterator for WaitEventsIterator<'a> {
             // calling poll_events()
             if let Some(ev) = self.window.poll_events().next() {
                 return Some(ev);
+            } else {
+                return Some(Awakened);
             }
         }
     }

--- a/src/events.rs
+++ b/src/events.rs
@@ -34,6 +34,9 @@ pub enum Event {
 
     /// The event loop was woken up by another thread.
     Awakened,
+
+    /// The window needs to be redrawn.
+    Refresh,
 }
 
 pub type ScanCode = u8;

--- a/src/x11/ffi.rs
+++ b/src/x11/ffi.rs
@@ -1369,6 +1369,12 @@ pub struct XErrorEvent {
     pub minor_code: libc::c_char,
 }
 
+#[repr(C)]
+pub struct XClassHint {
+    pub res_name: *const libc::c_char,
+    pub res_class: *const libc::c_char,
+}
+
 #[cfg(feature = "headless")]
 #[link(name = "OSMesa")]
 extern "C" {
@@ -1460,7 +1466,7 @@ extern "C" {
         keysym_return: *mut KeySym, status_return: *mut Status) -> libc::c_int;
 
     pub fn XkbSetDetectableAutoRepeat(dpy: *mut Display, detectable: bool, supported_rtm: *mut bool) -> bool;
-    
+
     pub fn XF86VidModeSwitchToMode(dpy: *mut Display, screen: libc::c_int,
         modeline: *mut XF86VidModeModeInfo) -> Bool;
     pub fn XF86VidModeSetViewPort(dpy: *mut Display, screen: libc::c_int,
@@ -1470,6 +1476,9 @@ extern "C" {
 
     pub fn XcursorLibraryLoadCursor(dpy: *mut Display, name: *const libc::c_char) -> Cursor;
     pub fn XDefineCursor(dby: *mut Display, w: Window, cursor: Cursor);
+
+    pub fn XAllocClassHint() -> *mut XClassHint;
+    pub fn XSetClassHint(dpy: *mut Display, w: Window, class_hints: *mut XClassHint);
 }
 
 /*

--- a/src/x11/window/mod.rs
+++ b/src/x11/window/mod.rs
@@ -163,7 +163,12 @@ impl<'a> Iterator for PollEventsIterator<'a> {
                         return Some(Resized(cfg_event.width as u32, cfg_event.height as u32));
                     }
                 },
-    
+
+                ffi::Expose => {
+                    use events::Event::Refresh;
+                    return Some(Refresh);
+                },
+
                 ffi::MotionNotify => {
                     use events::Event::MouseMoved;
                     let event: &ffi::XMotionEvent = unsafe { mem::transmute(&xev) };

--- a/src/x11/window/mod.rs
+++ b/src/x11/window/mod.rs
@@ -481,6 +481,16 @@ impl Window {
             }
         }
 
+        // Set ICCCM WM_CLASS property based on initial window title
+        unsafe {
+            with_c_str(builder.title.as_slice(), |c_name| {
+                let hint = ffi::XAllocClassHint();
+                (*hint).res_name = c_name;
+                (*hint).res_class = c_name;
+                ffi::XSetClassHint(display, window, hint);
+                ffi::XFree(hint as *const libc::c_void);
+            });
+        }
 
         // creating GL context
         let (context, extra_functions) = unsafe {


### PR DESCRIPTION
This improves scrolling performance in Servo a lot, because scrolling
events in the queue would back up behind wakeup events.

r? @glennw or @metajack

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/glutin/18)

<!-- Reviewable:end -->
