### PR TITLE
Fix a double free corruption crash in some X drivers on exit.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,8 @@
 //!
 //! By default only `window` is enabled.
 
+#![feature(alloc)]
+
 #[macro_use]
 extern crate lazy_static;
 


### PR DESCRIPTION
This was previously in glutin, but was removed since Weak is not
marked stable here:

https://github.com/tomaka/glutin/commit/0f7bd9071e9b64acb9f13e253d49c3790e50d560

Some X drivers crash if the window isn't closed from the main thread.