### PR TITLE
implement get_platform_window() return for X11

### DIFF
--- a/src/x11/window/mod.rs
+++ b/src/x11/window/mod.rs
@@ -772,7 +772,7 @@ impl Window {
     }
 
     pub fn platform_window(&self) -> *mut libc::c_void {
-        unimplemented!()
+        self.x.window as *mut libc::c_void
     }
 
     /// See the docs in the crate root file.


### PR DESCRIPTION
Needed for Servo embedding