### PR TITLE
do not set colormap mask when creating new windows

### DIFF
--- a/src/x11/window/mod.rs
+++ b/src/x11/window/mod.rs
@@ -434,7 +434,7 @@ impl Window {
             swa
         };
 
-        let mut window_attributes = ffi::CWBorderPixel | ffi::CWColormap | ffi:: CWEventMask;
+        let mut window_attributes = ffi::CWBorderPixel | ffi:: CWEventMask;
         if builder.monitor.is_some() {
             window_attributes |= ffi::CWOverrideRedirect;
             unsafe {


### PR DESCRIPTION
CopyFromParent fails if this is set

should fix #6042