### PR TITLE
Add X11 features required for linking against ffi functions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,8 +50,14 @@ kernel32-sys = "0.1"
 
 [target.i686-unknown-linux-gnu.dependencies]
 osmesa-sys = "*"
-x11 = "*"
 
 [target.x86_64-unknown-linux-gnu.dependencies]
 osmesa-sys = "*"
-x11 = "*"
+
+[target.i686-unknown-linux-gnu.dependencies.x11]
+version = "*"
+features = ["xlib", "xf86vmode", "xcursor"]
+
+[target.x86_64-unknown-linux-gnu.dependencies.x11]
+version = "*"
+features = ["xlib", "xf86vmode", "xcursor"]


### PR DESCRIPTION
r? @metajack 

Our version of glutin uses a different version of x11 bindings than upstream, so PR here. This version of x11 changed its set of features, which is breaking a PR that attempts to update x11 to pick up different things that broke elsewhere :-)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/glutin/28)
<!-- Reviewable:end -->
