### PR TITLE
Fix a rare crash in some X11 implementations (details below).

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,8 +23,6 @@
 //!
 //! By default only `window` is enabled.
 
-#![feature(arc_weak)]
-
 #[macro_use]
 extern crate lazy_static;
 


### PR DESCRIPTION
In some X11 implementations, calling XCloseDisplay from any thread
other than the main thread causes heap corruption and an eventual
crash.

Previously, the window proxy struct held a Weak<> ptr to the display,
which was upgraded to a strong arc only during the send of the X
message.

However, if the main thread closes the window *after* the thread
upgrades the weak ref, and this was the last strong reference,
then the only remaining strong reference is in the window proxy
thread, so the XCloseDisplay is executed on the thread.

Instead, use a simpler solution where the display reference used
by the window proxy threads is cleared by the main thread when
the window is closed, and the XCloseDisplay can only be executed
by the main thread.

This has the added benefit of not relying on the unstable Weak<>
library feature, so we will be able to get this upstreamed.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/glutin/37)
<!-- Reviewable:end -->
