### PR TITLE
Add aarch64-unknown-linux-gnu support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,10 +54,17 @@ osmesa-sys = "*"
 [target.x86_64-unknown-linux-gnu.dependencies]
 osmesa-sys = "*"
 
+[target.aarch64-unknown-linux-gnu.dependencies]
+osmesa-sys = "*"
+
 [target.i686-unknown-linux-gnu.dependencies.x11]
 version = "*"
 features = ["xlib", "xf86vmode", "xcursor"]
 
 [target.x86_64-unknown-linux-gnu.dependencies.x11]
+version = "*"
+features = ["xlib", "xf86vmode", "xcursor"]
+
+[target.aarch64-unknown-linux-gnu.dependencies.x11]
 version = "*"
 features = ["xlib", "xf86vmode", "xcursor"]

--- a/examples/support/mod.rs
+++ b/examples/support/mod.rs
@@ -22,7 +22,7 @@ pub fn load(window: &glutin::Window) -> Context {
     let gl = gl::Gl::load(window);
 
     let version = unsafe {
-        let data = CStr::from_ptr(gl.GetString(gl::VERSION) as *const i8).to_bytes().to_vec();
+        let data = CStr::from_ptr(gl.GetString(gl::VERSION) as *const _).to_bytes().to_vec();
         String::from_utf8(data).unwrap()
     };
 

--- a/src/x11/window/mod.rs
+++ b/src/x11/window/mod.rs
@@ -546,8 +546,8 @@ impl Window {
         unsafe {
             with_c_str(&*builder.title, |c_name| {
                 let hint = ffi::XAllocClassHint();
-                (*hint).res_name = c_name as *mut i8;
-                (*hint).res_class = c_name as *mut i8;
+                (*hint).res_name = c_name as *mut ::libc::c_char;
+                (*hint).res_class = c_name as *mut ::libc::c_char;
                 ffi::XSetClassHint(display, window, hint);
                 ffi::XFree(hint as *mut libc::c_void);
             });


### PR DESCRIPTION
* Adding dependencies
* Replacing `i8` with `::libc::c_char` (since `c_char` can be
  unsigned on some platforms, aarch64 is one of them)
* Adding `extern crate libc;` to examples

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/glutin/38)
<!-- Reviewable:end -->
