### PR TITLE
Re-apply missing win32 patch

### DIFF
--- a/src/api/win32/mod.rs
+++ b/src/api/win32/mod.rs
@@ -254,7 +254,8 @@ impl Window {
 
     #[inline]
     pub fn set_cursor(&self, _cursor: MouseCursor) {
-        unimplemented!()
+        // XXX FIXME -- ignore this for now, we need to implement this
+        //unimplemented!()
     }
 
     pub fn set_cursor_state(&self, state: CursorState) -> Result<(), String> {

--- a/src/api/x11/window.rs
+++ b/src/api/x11/window.rs
@@ -401,13 +401,11 @@ impl Window {
             },
         };
 
-        // getting the parent window
-        let parent = if window_attrs.parent.is_null() {
-                         unsafe { (display.xlib.XDefaultRootWindow)(display.display) }
-        } else {
-            window_attrs.parent as ffi::Window
+        // getting the parent window; root if None
+        let parent = match window_attrs.parent {
+            Some(ref w) => w.window as ffi::Window,
+            None => unsafe { (display.xlib.XDefaultRootWindow)(display.display) }
         };
-        // getting the root window
 
         // creating the color map
         let cmap = unsafe {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -519,6 +519,23 @@ impl Default for PixelFormatRequirements {
     }
 }
 
+/// A wrapper for a native window pointer.
+#[derive(Debug, Clone)]
+pub struct WindowID {
+    pub window: *mut libc::c_void,
+}
+
+impl WindowID {
+    pub fn new(window: *mut libc::c_void) -> WindowID {
+        WindowID {
+            window: window
+        }
+    }
+}
+
+unsafe impl Send for WindowID {}
+unsafe impl Sync for WindowID {}
+
 /// Attributes to use when creating a window.
 #[derive(Clone)]
 pub struct WindowAttributes {
@@ -560,8 +577,8 @@ pub struct WindowAttributes {
 
     /// Parent Window.
     ///
-    /// The default is `std::ptr::null_mut()`
-    pub parent: WindowID,
+    /// The default is `None`.
+    pub parent: Option<WindowID>,
 }
 
 impl Default for WindowAttributes {
@@ -575,7 +592,7 @@ impl Default for WindowAttributes {
             transparent: false,
             decorations: true,
             multitouch: false,
-            parent: std::ptr::null_mut(),
+            parent: None,
         }
     }
 }
@@ -662,6 +679,3 @@ mod native_monitor {
         Unavailable
     }
 }
-
-/// Identifier for a display system window.
-pub type WindowID = *mut libc::c_void;

--- a/src/window.rs
+++ b/src/window.rs
@@ -197,7 +197,7 @@ impl<'a> WindowBuilder<'a> {
     }
 
     /// Sets the parent window
-    pub fn with_parent(mut self, parent: WindowID) -> WindowBuilder<'a> {
+    pub fn with_parent(mut self, parent: Option<WindowID>) -> WindowBuilder<'a> {
         self.window.parent = parent;
         self
     }


### PR DESCRIPTION
This was lost in a recent rebase onto upstream master (#51). r? @vvuk

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/glutin/52)

<!-- Reviewable:end -->
