### PR TITLE
Fixes for VirtualBox

### DIFF
--- a/src/api/glx/mod.rs
+++ b/src/api/glx/mod.rs
@@ -371,10 +371,6 @@ unsafe fn enumerate_configs(glx: &ffi::glx::Glx, xlib: &ffi::Xlib, display: *mut
     };
 
     Ok(configs.into_iter().filter_map(|config| {
-        if get_attrib(ffi::glx::X_RENDERABLE as libc::c_int, config) == 0 {
-            return None;
-        }
-
         if get_attrib(ffi::glx::X_VISUAL_TYPE as libc::c_int, config) !=
                                                         ffi::glx::TRUE_COLOR as libc::c_int
         {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -433,10 +433,6 @@ impl PixelFormatRequirements {
                     Some(val) if val >= req_ms => (),
                     _ => return false
                 }
-            } else {
-                if format.multisampling.is_some() {
-                    return false;
-                }
             }
 
             if let Some(srgb) = self.srgb {


### PR DESCRIPTION
This allows Servo to boot under VirtualBox.

One of these patches has gone upstream: https://github.com/tomaka/glutin/pull/686

The other two don't apply upstream because the code in question has been totally rewritten there.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/glutin/58)

<!-- Reviewable:end -->
