### PR TITLE
Support HiDPI on Linux by querying the Xft DPI through XSETTINGS.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ name = "glutin"
 [features]
 default = []
 headless = []
+use-xsettings = ["xsettings"]
 
 [dependencies]
 gl_common = "0.1.0"
@@ -94,12 +95,20 @@ wayland-kbd = "0.3.3"
 wayland-window = "0.2.2"
 x11-dl = "~2.2"
 
+[target.i686-unknown-linux-gnu.dependencies.xsettings]
+version = "0.2"
+optional = true
+
 [target.x86_64-unknown-linux-gnu.dependencies]
 osmesa-sys = "0.0.5"
 wayland-client = { version = "0.5.4", features = ["egl", "dlopen"] }
 wayland-kbd = "0.3.3"
 wayland-window = "0.2.2"
 x11-dl = "~2.2"
+
+[target.x86_64-unknown-linux-gnu.dependencies.xsettings]
+version = "0.2"
+optional = true
 
 [target.arm-unknown-linux-gnueabihf.dependencies]
 osmesa-sys = "0.0.5"
@@ -108,12 +117,20 @@ wayland-kbd = "0.3.3"
 wayland-window = "0.2.2"
 x11-dl = "~2.2"
 
+[target.arm-unknown-linux-gnueabihf.dependencies.xsettings]
+version = "0.2"
+optional = true
+
 [target.aarch64-unknown-linux-gnu.dependencies]
 osmesa-sys = "0.0.5"
 wayland-client = { version = "0.5.4", features = ["egl", "dlopen"] }
 wayland-kbd = "0.3.3"
 wayland-window = "0.2.2"
 x11-dl = "~2.2"
+
+[target.aarch64-unknown-linux-gnu.dependencies.xsettings]
+version = "0.2"
+optional = true
 
 [target.x86_64-unknown-dragonfly.dependencies]
 osmesa-sys = "0.0.5"
@@ -122,12 +139,20 @@ wayland-kbd = "0.3.3"
 wayland-window = "0.2.2"
 x11-dl = "~2.2"
 
+[target.x86_64-unknown-dragonfly.dependencies.xsettings]
+version = "0.2"
+optional = true
+
 [target.x86_64-unknown-freebsd.dependencies]
 osmesa-sys = "0.0.5"
 wayland-client = { version = "0.5.4", features = ["egl", "dlopen"] }
 wayland-kbd = "0.3.3"
 wayland-window = "0.2.2"
 x11-dl = "~2.2"
+
+[target.x86_64-unknown-freebsd.dependencies.xsettings]
+version = "0.2"
+optional = true
 
 [target.i686-unknown-linux-gnu.dependencies.x11]
 version = "2.2"

--- a/src/api/x11/window.rs
+++ b/src/api/x11/window.rs
@@ -35,6 +35,11 @@ lazy_static! {      // TODO: use a static mutex when that's possible, and put me
     static ref GLOBAL_XOPENIM_LOCK: Mutex<()> = Mutex::new(());
 }
 
+#[cfg(not(feature = "use-xsettings"))]
+pub type XSettingsClient = ();
+#[cfg(feature = "use-xsettings")]
+pub type XSettingsClient = ::xsettings::Client;
+
 // TODO: remove me
 fn with_c_str<F, T>(s: &str, f: F) -> T where F: FnOnce(*const libc::c_char) -> T {
     use std::ffi::CString;
@@ -298,7 +303,13 @@ pub struct Window {
     /// Events that have been retreived with XLib but not dispatched with iterators yet
     pending_events: Mutex<VecDeque<Event>>,
     cursor_state: Mutex<CursorState>,
-    input_handler: Mutex<XInputEventHandler>
+    input_handler: Mutex<XInputEventHandler>,
+    /// The XSETTINGS client. This trips the dead code warning because we never consult it after
+    /// the initial HiDPI query. But we really should be listening for HiDPI change events, and
+    /// when that happens we'll need to keep the client around. So we might as well store it here.
+    #[allow(dead_code)]
+    xsettings_client: XSettingsClient,
+    current_hidpi_factor: f32,
 }
 
 impl Window {
@@ -306,16 +317,21 @@ impl Window {
                pf_reqs: &PixelFormatRequirements, opengl: &GlAttributes<&Window>)
                -> Result<Window, CreationError>
     {
-        let dimensions = window_attrs.dimensions.unwrap_or((800, 600));
-
-        // not implemented
-        assert!(window_attrs.min_dimensions.is_none());
-        assert!(window_attrs.max_dimensions.is_none());
-
         let screen_id = match window_attrs.monitor {
             Some(PlatformMonitorId::X(MonitorId(_, monitor))) => monitor as i32,
             _ => unsafe { (display.xlib.XDefaultScreen)(display.display) },
         };
+
+        let xsettings_client = display.create_xsettings_client(screen_id);
+        let hidpi_factor = query_hidpi_factor(&xsettings_client);
+
+        let mut dimensions = window_attrs.dimensions.unwrap_or((800, 600));
+        dimensions = ((dimensions.0 as f32 * hidpi_factor) as u32,
+                      (dimensions.1 as f32 * hidpi_factor) as u32);
+
+        // not implemented
+        assert!(window_attrs.min_dimensions.is_none());
+        assert!(window_attrs.max_dimensions.is_none());
 
         // finding the mode to switch to if necessary
         let (mode_to_switch_to, xf86_desk_mode) = unsafe {
@@ -636,11 +652,16 @@ impl Window {
                 window_proxy_data: window_proxy_data,
             }),
             is_closed: AtomicBool::new(false),
-            wm_delete_window: wm_delete_window,
-            current_size: Cell::new((0, 0)),
+            wm_delete_window: wm_delete_window, current_size: Cell::new((0, 0)),
             pending_events: Mutex::new(VecDeque::new()),
             cursor_state: Mutex::new(CursorState::Normal),
-            input_handler: Mutex::new(XInputEventHandler::new(display, window, ic, window_attrs))
+            input_handler: Mutex::new(XInputEventHandler::new(display,
+                                                              window,
+                                                              ic,
+                                                              window_attrs,
+                                                              hidpi_factor)),
+            xsettings_client: xsettings_client,
+            current_hidpi_factor: hidpi_factor,
         };
 
         if window_attrs.visible {
@@ -724,7 +745,11 @@ impl Window {
                 return None;
             }
 
-            Some((x as i32, y as i32, width as u32, height as u32, border as u32))
+            Some((x as i32,
+                  y as i32,
+                  self.device_pixels_to_screen_pixels(width as f32) as u32,
+                  self.device_pixels_to_screen_pixels(height as f32) as u32,
+                  border as u32))
         }
     }
 
@@ -750,7 +775,13 @@ impl Window {
 
     #[inline]
     pub fn set_inner_size(&self, x: u32, y: u32) {
-        unsafe { (self.x.display.xlib.XResizeWindow)(self.x.display.display, self.x.window, x as libc::c_uint, y as libc::c_uint); }
+        unsafe {
+            (self.x.display.xlib.XResizeWindow)(
+                self.x.display.display,
+                self.x.window,
+                self.screen_pixels_to_device_pixels(x as f32) as libc::c_uint,
+                self.screen_pixels_to_device_pixels(y as f32) as libc::c_uint);
+        }
         self.x.display.check_errors().expect("Failed to call XResizeWindow");
     }
 
@@ -893,9 +924,8 @@ impl Window {
         }
     }
 
-    #[inline]
     pub fn hidpi_factor(&self) -> f32 {
-        1.0
+        self.current_hidpi_factor
     }
 
     pub fn set_cursor_position(&self, x: i32, y: i32) -> Result<(), ()> {
@@ -903,6 +933,18 @@ impl Window {
             (self.x.display.xlib.XWarpPointer)(self.x.display.display, 0, self.x.window, 0, 0, 0, 0, x, y);
             self.x.display.check_errors().map_err(|_| ())
         }
+    }
+
+    pub fn device_pixels_to_screen_pixels<N>(&self, device_pixels: N) -> N
+                                             where N: From<f32> + Into<f32> {
+        let device_pixels: f32 = device_pixels.into();
+        (device_pixels / self.hidpi_factor()).into()
+    }
+
+    pub fn screen_pixels_to_device_pixels<N>(&self, device_pixels: N) -> N
+                                             where N: From<f32> + Into<f32> {
+        let device_pixels: f32 = device_pixels.into();
+        (device_pixels * self.hidpi_factor()).into()
     }
 }
 
@@ -961,3 +1003,22 @@ impl GlContext for Window {
         }
     }
 }
+
+#[cfg(not(feature = "use-xsettings"))]
+fn query_hidpi_factor(_: &XSettingsClient) -> f32 {
+    1.0
+}
+
+#[cfg(feature = "use-xsettings")]
+fn query_hidpi_factor(xsettings_client: &XSettingsClient) -> f32 {
+    match xsettings_client.get_setting(b"Xft/DPI") {
+        Ok(setting) => {
+            match setting.data() {
+                ::xsettings::SettingData::Int(dpi) => (dpi as f32) / 98304.0,
+                _ => 1.0,
+            }
+        }
+        Err(_) => 1.0,
+    }
+}
+

--- a/src/api/x11/window.rs
+++ b/src/api/x11/window.rs
@@ -648,8 +648,13 @@ impl Window {
                 let ref x_window: &XWindow = window.x.borrow();
 
                 // XSetInputFocus generates an error if the window is not visible,
-                // therefore we call XSync before to make sure it's the case
-                (display.xlib.XSync)(display.display, 0);
+                // therefore we call XIfEvent before and listen to the Expose event
+                let mut event = mem::zeroed();
+                (display.xlib.XIfEvent)(display.display,
+                                        &mut event,
+                                        Some(check_event),
+                                        ptr::null_mut());
+
                 (display.xlib.XSetInputFocus)(
                     display.display,
                     x_window.window,
@@ -657,6 +662,17 @@ impl Window {
                     ffi::CurrentTime
                 );
                 display.check_errors().expect("Failed to call XSetInputFocus");
+
+                unsafe extern "C" fn check_event(_: *mut ffi::Display,
+                                                 event: *mut ffi::XEvent,
+                                                 _: *mut i8)
+                                                 -> ffi::Bool {
+                    if (*event).get_type() == ffi::Expose {
+                        ffi::True
+                    } else {
+                        ffi::False
+                    }
+                }
             }
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,9 @@ extern crate x11_dl;
 #[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "dragonfly"))]
 #[macro_use(wayland_env)]
 extern crate wayland_client;
+#[cfg(all(any(target_os = "linux", target_os = "freebsd", target_os = "dragonfly"),
+          feature = "use-xsettings"))]
+extern crate xsettings;
 
 pub use events::*;
 pub use headless::{HeadlessRendererBuilder, HeadlessContext};


### PR DESCRIPTION
The Xft DPI is set when the user adjusts the scale in the Ubuntu
"Displays" preference pane.

This depends on `rust-xsettings`, which in turn uses the C library
`libxsettings-client-0`. Unfortunately, this library is not installed by
default on most Linux distributions. To avoid unnecessary dependencies,
this commit places support for HiDPI on Linux behind the `use-xsettings`
Cargo feature.

This has gone upstream: https://github.com/tomaka/glutin/pull/698

r? @glennw (or whoever)

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/glutin/60)

<!-- Reviewable:end -->
