### PR TITLE
Stop using `NSFullSizeContentViewWindowMask` to get borderless windows,

### DIFF
--- a/src/api/cocoa/mod.rs
+++ b/src/api/cocoa/mod.rs
@@ -291,7 +291,7 @@ impl Window {
             Some(window) => window,
             None         => { return Err(OsError(format!("Couldn't create NSWindow"))); },
         };
-        let view = match Window::create_view(*window) {
+        let view = match Window::get_or_create_view(*window, win_attribs.decorations) {
             Some(view) => view,
             None       => { return Err(OsError(format!("Couldn't create NSView"))); },
         };
@@ -412,8 +412,7 @@ impl Window {
                 NSClosableWindowMask as NSUInteger |
                 NSMiniaturizableWindowMask as NSUInteger |
                 NSResizableWindowMask as NSUInteger |
-                NSTitledWindowMask as NSUInteger |
-                NSFullSizeContentViewWindowMask as NSUInteger
+                NSTitledWindowMask as NSUInteger
             };
 
             let window = IdRef::new(NSWindow::alloc(nil).initWithContentRect_styleMask_backing_defer_(
@@ -428,8 +427,24 @@ impl Window {
                 window.setAcceptsMouseMovedEvents_(YES);
 
                 if !attrs.decorations {
+                    // Make titles invisible so that nothing is drawn.
                     window.setTitleVisibility_(NSWindowTitleVisibility::NSWindowTitleHidden);
                     window.setTitlebarAppearsTransparent_(YES);
+
+                    // Get rid of all the buttons so that they won't be drawn and the user can't
+                    // click them.
+                    for &button_type in &[
+                        NSWindowButton::NSWindowCloseButton,
+                        NSWindowButton::NSWindowMiniaturizeButton,
+                        NSWindowButton::NSWindowZoomButton,
+                        NSWindowButton::NSWindowToolbarButton,
+                        NSWindowButton::NSWindowFullScreenButton,
+                    ] {
+                        if let Some(button) =
+                                IdRef::new(window.standardWindowButton_(button_type)).non_nil() {
+                            button.removeFromSuperview()
+                        }
+                    }
                 }
 
                 if screen.is_some() {
@@ -443,14 +458,29 @@ impl Window {
         }
     }
 
-    fn create_view(window: id) -> Option<IdRef> {
+    fn get_or_create_view(window: id, decorations: bool) -> Option<IdRef> {
         unsafe {
-            let view = IdRef::new(NSView::alloc(nil).init());
-            view.non_nil().map(|view| {
-                view.setWantsBestResolutionOpenGLSurface_(YES);
-                window.setContentView_(*view);
-                view
-            })
+            if decorations {
+                let view = IdRef::new(NSView::alloc(nil).init());
+                return view.non_nil().map(|view| {
+                    view.setWantsBestResolutionOpenGLSurface_(YES);
+                    window.setContentView_(*view);
+                    view
+                })
+            }
+
+            // This hack is a little evil. We get the superview of the content view, which is the
+            // `NSThemeFrame`, and install an OpenGL context into it. `NSThemeFrame` is a private
+            // class, but we only call public `NSView` APIs on it here, so this seems OK.
+            //
+            // The reason for using this hack as opposed to `NSFullSizeContentViewWindowMask` is
+            // that the latter forces the window to be Core Animation-backed, which results in us
+            // rendering to an off screen surface. Not only does this inject another compositor
+            // into the system, but it also results in us rendering to an off-screen surface,
+            // disabling the swap interval.
+            let view = window.contentView().superview();
+            view.setWantsBestResolutionOpenGLSurface_(YES);
+            Some(IdRef::new(view))
         }
     }
 


### PR DESCRIPTION
because that disables the swap interval.

This hack is very simple but a little evil. We get the superview of the
content view, which is the `NSThemeFrame`, and install an OpenGL context
into it.  `NSThemeFrame` is a private class, but we only call public
`NSView` APIs on it here, so this seems OK in terms of being supported
by Apple going forward.

The reason for using this hack as opposed to
`NSFullSizeContentViewWindowMask` is that the latter forces the window
to be Core Animation-backed, which results in us rendering to an off
screen surface. Not only does this inject another compositor into the
system, but it also results in us rendering to an off-screen surface,
disabling the swap interval.

This depends on a `cocoa-rs` upgrade to add a binding to the `-[NSView
superview]` method.

Known issues:
- The traffic light buttons are not drawn but still function if you
  click on them. This can be worked around in browser.html.
- The top border is not rounded, although the shadow properly displays.
  This should be able to be worked around in browser.html.
- The title bar reappears if you go to full screen and then go back.
  This is the most serious issue, but I suspect it'll be fixable and
  it's better than what we have right now.

This should fix servo/servo#9431.

r? @jdm

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/glutin/68)

<!-- Reviewable:end -->
