### PR TITLE
cocoa: Post Awakened events at the end of the queue to avoid floods.

### DIFF
--- a/src/api/cocoa/mod.rs
+++ b/src/api/cocoa/mod.rs
@@ -201,7 +201,7 @@ impl WindowProxy {
                 NSEvent::otherEventWithType_location_modifierFlags_timestamp_windowNumber_context_subtype_data1_data2_(
                     nil, NSApplicationDefined, NSPoint::new(0.0, 0.0), NSEventModifierFlags::empty(),
                     0.0, 0, nil, NSApplicationActivatedEventType, 0, 0);
-            NSApp().postEvent_atStart_(event, YES);
+            NSApp().postEvent_atStart_(event, NO);
             pool.drain();
         }
     }


### PR DESCRIPTION
Closes servo/webrender#179.

r? @glennw

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/glutin/72)

<!-- Reviewable:end -->
