### PR TITLE
Pin core-graphics to 0.2 since cocoa 0.2.4 does

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ objc = "0.1.8"
 cgl = "0.1"
 cocoa = "0.2.4"
 core-foundation = "0"
-core-graphics = "0"
+core-graphics = "0.2"
 
 [target.i686-pc-windows-gnu.dependencies]
 winapi = "0.2"


### PR DESCRIPTION
<!-- Reviewable:start -->

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/glutin/74)

<!-- Reviewable:end -->
