### PR TITLE
Support proper transparent shadows on the Mac.

### DIFF
--- a/src/api/cocoa/mod.rs
+++ b/src/api/cocoa/mod.rs
@@ -740,6 +740,18 @@ impl Window {
 
         Ok(())
     }
+
+    /// Tells Cocoa to rebuild the window shadow (in a roundabout way).
+    ///
+    /// Yes, this is really the Apple-recommended way to do this. See:
+    ///
+    ///     https://developer.apple.com/library/mac/samplecode/RoundTransparentWindow/
+    fn reset_shadow(&self) {
+        unsafe {
+            NSWindow::setHasShadow_(*self.window, NO);
+            NSWindow::setHasShadow_(*self.window, YES);
+        }
+    }
 }
 
 impl GlContext for Window {
@@ -789,6 +801,11 @@ impl GlContext for Window {
     #[inline]
     fn get_pixel_format(&self) -> PixelFormat {
         self.pixel_format.clone()
+    }
+
+    #[inline]
+    fn framebuffer_alpha_changed(&self) {
+        self.reset_shadow();
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,6 +131,12 @@ pub trait GlContext {
 
     /// Returns the pixel format of the main framebuffer of the context.
     fn get_pixel_format(&self) -> PixelFormat;
+
+    /// Informs the window manager that the alpha component of the framebuffer has changed.
+    ///
+    /// This is used on Mac OS X to update the window shadow for borderless, transparent windows.
+    /// On that platform, this is an expensive operation, so you should not call this too often.
+    fn framebuffer_alpha_changed(&self) {}
 }
 
 /// Error that can happen while creating a window or a headless renderer.

--- a/src/window.rs
+++ b/src/window.rs
@@ -517,6 +517,15 @@ impl Window {
     pub fn set_cursor_state(&self, state: CursorState) -> Result<(), String> {
         self.window.set_cursor_state(state)
     }
+
+    /// Informs the window manager that the alpha component of the framebuffer has changed.
+    ///
+    /// This is used on Mac OS X to update the window shadow for borderless, transparent windows.
+    /// On that platform, this is an expensive operation, so you should not call this too often.
+    #[inline]
+    pub fn framebuffer_alpha_changed(&self) {
+        self.window.framebuffer_alpha_changed()
+    }
 }
 
 impl GlContext for Window {


### PR DESCRIPTION
This unfortunately requires the application to tell Glutin explicitly
whenever it changes the alpha component of the framebuffer, because
rebuilding the shadow automatically after every buffer swap is too slow.
A new method, `framebuffer_alpha_changed()`, has been added to support
this.

r? @paulrouget

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/glutin/75)

<!-- Reviewable:end -->
