### PR TITLE
Make Mac borderless windows resizable and draggable.

### DIFF
--- a/src/api/cocoa/mod.rs
+++ b/src/api/cocoa/mod.rs
@@ -404,7 +404,9 @@ impl Window {
 
             let masks = if screen.is_some() || attrs.transparent {
                 // Fullscreen or transparent window
-                NSBorderlessWindowMask as NSUInteger
+                NSBorderlessWindowMask as NSUInteger |
+                NSResizableWindowMask as NSUInteger |
+                NSTitledWindowMask as NSUInteger
             } else if attrs.decorations {
                 // Classic opaque window with titlebar
                 NSClosableWindowMask as NSUInteger |


### PR DESCRIPTION
Despite the fact that the style mask contains `NSTitledWindowMask`, the
title doesn't show up for two reasons: (a) we draw over it; (b) we make
it invisible with a call to `-[NSWindow setTitleVisibility:]`.

Addresses servo/servo#9877 and servo/servo#9878.

r? @metajack 
cc @paulrouget 

Submitted upstream at https://github.com/tomaka/glutin/pull/740.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/glutin/77)

<!-- Reviewable:end -->
