### PR TITLE
Downgrade our `core-graphics-rs` version so that we don't pull in serde 0.7.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "servo-glutin"
-version = "0.4.11"
+version = "0.4.12"
 authors = ["The glutin contributors, Pierre Krieger <pierre.krieger1708@gmail.com>"]
 description = "Cross-platform OpenGL context provider."
 keywords = ["windowing", "opengl"]
@@ -49,7 +49,7 @@ objc = "0.1.8"
 cgl = "0.1"
 cocoa = "0.2.4"
 core-foundation = "0"
-core-graphics = "0.3"
+core-graphics = ">=0.2, <0.4"
 
 [target.i686-pc-windows-gnu.dependencies]
 winapi = "0.2"


### PR DESCRIPTION
Servo isn't ready for that upgrade yet.

r? @metajack (or whoever)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/glutin/79)

<!-- Reviewable:end -->
