### PR TITLE
cocoa: Add a new platform-specific API that allows library consumers to specify that only the corners of a window can be transparent.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,9 +46,9 @@ objc = "0.2"
 [target.x86_64-apple-darwin.dependencies]
 objc = "0.2"
 cgl = "0.1"
-cocoa = "0.4.1"
+cocoa = "0.4.2"
 core-foundation = "0.2.2"
-core-graphics = ">=0.2, <0.4"
+core-graphics = "0.3.1"
 
 [target.i686-pc-windows-gnu.dependencies]
 winapi = "0.2"

--- a/src/os/macos.rs
+++ b/src/os/macos.rs
@@ -54,6 +54,8 @@ impl From<ActivationPolicy> for NSApplicationActivationPolicy {
 pub trait WindowBuilderExt<'a> {
     fn with_activation_policy(mut self, activation_policy: ActivationPolicy) -> WindowBuilder<'a>;
     fn with_app_name(mut self, app_name: String) -> WindowBuilder<'a>;
+    fn with_transparent_corner_radius(mut self, transparent_corner_radius: u32)
+                                      -> WindowBuilder<'a>;
 }
 
 impl<'a> WindowBuilderExt<'a> for WindowBuilder<'a> {
@@ -68,6 +70,17 @@ impl<'a> WindowBuilderExt<'a> for WindowBuilder<'a> {
     #[inline]
     fn with_app_name(mut self, app_name: String) -> WindowBuilder<'a> {
         self.platform_specific.app_name = Some(app_name);
+        self
+    }
+
+    /// Sets the maximum number of pixels from the corners that transparent content will be drawn
+    ///
+    /// This is used as an optimization so that Cocoa won't have to paint what's behind most of the
+    /// window. It improves performance dramatically when in use when videos, transparent Terminal
+    /// windows, etc. are behind the window.
+    fn with_transparent_corner_radius(mut self, transparent_corner_radius: u32)
+                                      -> WindowBuilder<'a> {
+        self.platform_specific.transparent_corner_radius = Some(transparent_corner_radius);
         self
     }
 }


### PR DESCRIPTION
By doing this, we significantly improve performance by allowing the
window server to perform occlusion culling under most of the window.

This patch relies on the private `CGSRegion` and the private
`-[NSCGSWindow setOpaqueRegion:]` APIs.

Requires servo/core-graphics-rs#50 and servo/cocoa-rs#129.

r? @metajack

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/glutin/94)

<!-- Reviewable:end -->
