### PR TITLE
Use the private `CGSSetSurfaceShape` API to make the OpenGL view inside an undecorated window have rounded corners.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ objc = "0.2"
 cgl = "0.1"
 cocoa = "0.4.2"
 core-foundation = "0.2.2"
-core-graphics = "0.3.1"
+core-graphics = "0.3.2"
 
 [target.i686-pc-windows-gnu.dependencies]
 winapi = "0.2"

--- a/src/os/macos.rs
+++ b/src/os/macos.rs
@@ -54,8 +54,6 @@ impl From<ActivationPolicy> for NSApplicationActivationPolicy {
 pub trait WindowBuilderExt<'a> {
     fn with_activation_policy(mut self, activation_policy: ActivationPolicy) -> WindowBuilder<'a>;
     fn with_app_name(mut self, app_name: String) -> WindowBuilder<'a>;
-    fn with_transparent_corner_radius(mut self, transparent_corner_radius: u32)
-                                      -> WindowBuilder<'a>;
 }
 
 impl<'a> WindowBuilderExt<'a> for WindowBuilder<'a> {
@@ -70,17 +68,6 @@ impl<'a> WindowBuilderExt<'a> for WindowBuilder<'a> {
     #[inline]
     fn with_app_name(mut self, app_name: String) -> WindowBuilder<'a> {
         self.platform_specific.app_name = Some(app_name);
-        self
-    }
-
-    /// Sets the maximum number of pixels from the corners that transparent content will be drawn
-    ///
-    /// This is used as an optimization so that Cocoa won't have to paint what's behind most of the
-    /// window. It improves performance dramatically when in use when videos, transparent Terminal
-    /// windows, etc. are behind the window.
-    fn with_transparent_corner_radius(mut self, transparent_corner_radius: u32)
-                                      -> WindowBuilder<'a> {
-        self.platform_specific.transparent_corner_radius = Some(transparent_corner_radius);
         self
     }
 }


### PR DESCRIPTION
This allows us to disable transparency on the OpenGL surface, which is a
huge performance win on browser.html. It mirrors the way that Cocoa
internally makes OpenGL views inherit rounded corners.

Requires servo/core-graphics-rs#51.

r? @metajack 
cc @paulrouget

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/glutin/95)

<!-- Reviewable:end -->
