### PR TITLE
cocoa: Activate the `NSApplication` instance after the event loop is set up, and use `orderFrontRegardless` to more reliably pop up the main window.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ objc = "0.2"
 [target.x86_64-apple-darwin.dependencies]
 objc = "0.2"
 cgl = "0.1"
-cocoa = "0.4.2"
+cocoa = "0.4.4"
 core-foundation = "0.2.2"
 core-graphics = "0.3.2"
 


### PR DESCRIPTION
This makes the menus work right away when the app is started.

See e.g. http://czak.pl/2015/09/23/single-file-cocoa-app-with-swift.html

r? @metajack

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/glutin/96)

<!-- Reviewable:end -->
