### PR TITLE
fix return coordinates in MouseInput

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "servo-glutin"
-version = "0.4.23"
+version = "0.4.24"
 authors = ["The glutin contributors, Pierre Krieger <pierre.krieger1708@gmail.com>"]
 description = "Cross-platform OpenGL context provider."
 keywords = ["windowing", "opengl"]


### PR DESCRIPTION
It is a fix of #97 
When working on [servo/#11794](https://github.com/servo/servo/pull/11794). I found the previous PR #97 is wrong. This PR is a fix of that and is right when testing [servo/#11794](https://github.com/servo/servo/pull/11794).
Actually, we should return the mouse movement position instead of actual coordination. So the previous PR's return value is wrong.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/glutin/99)

<!-- Reviewable:end -->
