### PR TITLE
Android life cycle improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "servo-glutin"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["The glutin contributors, Pierre Krieger <pierre.krieger1708@gmail.com>"]
 description = "Cross-platform OpenGL context provider."
 keywords = ["windowing", "opengl"]


### PR DESCRIPTION
- Handle Activity Life Cycle: EGLContext is lost when the app goes to background and needs to be restored when the activity goes to foreground. Stop animation loop when the Activity stopped.
- Handle event loop awake for Servo Animation loop
- Handle screen resize events
- Handle orientation changed events

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/glutin/117)
<!-- Reviewable:end -->
