### PR TITLE
Update cgl to v0.2 and README

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "servo-glutin"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["The glutin contributors, Pierre Krieger <pierre.krieger1708@gmail.com>"]
 description = "Cross-platform OpenGL context provider."
 keywords = ["windowing", "opengl"]
@@ -33,7 +33,7 @@ objc = "0.2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc = "0.2"
-cgl = "0.1"
+cgl = "0.2"
 cocoa = "0.8"
 core-foundation = "0.3"
 core-graphics = "0.7"

--- a/README.md
+++ b/README.md
@@ -45,14 +45,16 @@ fn main() {
 
     unsafe { window.make_current() };
 
-    unsafe {
-        gl::load_with(|symbol| window.get_proc_address(symbol) as *const _);
+    let gl_ = match gl::GlType::default() {
+        gl::GlType::Gl => gl::GlFns::load_with(|symbol| window.get_proc_address(symbol) as *const _),
+        gl::GlType::Gles => gl::GlesFns::load_with(|symbol| window.get_proc_address(symbol) as *const _),
+    };
 
-        gl::ClearColor(0.0, 1.0, 0.0, 1.0);
-    }
+
+    gl_.clear_color(0.0, 1.0, 0.0, 1.0);
 
     for event in window.wait_events() {
-        unsafe { gl::Clear(gl::COLOR_BUFFER_BIT) };
+        gl_.clear(gl::COLOR_BUFFER_BIT);
         window.swap_buffers();
 
         match event {


### PR DESCRIPTION
This fixes #118.
README.md is also updated as to assume gleam v0.3.0, since cgl v0.2 uses it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/glutin/119)
<!-- Reviewable:end -->
