### PR TITLE
Fix Android swap_buffers panic when the app goes to background

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "servo-glutin"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["The glutin contributors, Pierre Krieger <pierre.krieger1708@gmail.com>"]
 description = "Cross-platform OpenGL context provider."
 keywords = ["windowing", "opengl"]


### PR DESCRIPTION
Fixes a panic on swap_buffers call because NativeActivity's `TermWindow (on_surface_destroyed)` event can be processed with some delay due to multithreading communication and a swap_buffers call from Servo may arrive in that period of time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/glutin/121)
<!-- Reviewable:end -->
