### PR TITLE
macos: Map our user generated event to Event::Awakened

### DIFF
--- a/src/api/cocoa/mod.rs
+++ b/src/api/cocoa/mod.rs
@@ -1145,6 +1145,12 @@ unsafe fn NSEventToEvent(window: &Window, nsevent: id) -> Option<Event> {
         appkit::NSEventTypePressure => {
             Some(Event::TouchpadPressure(nsevent.pressure(), nsevent.stage()))
         },
+        appkit::NSApplicationDefined => {
+            match nsevent.subtype() {
+                appkit::NSEventSubtype::NSApplicationActivatedEventType => { Some(Event::Awakened) }
+                _ => { None }
+            }
+        },
         _  => { None },
     }
 }


### PR DESCRIPTION
This fixes propagation of Event::Awakend from wakeup_event_loop() when
using poll_event() on macOS.

Currently wait_event() translates all unknown events into
Event::Awakened so doesn't need the explicit translation.

This comes from 3b1fdc0f55e5040667db40846b79783e017604fc in winit

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/glutin/123)
<!-- Reviewable:end -->
