### PR TITLE
Bump version to 0.10.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "servo-glutin"
-version = "0.10.1"
+version = "0.10.2"
 authors = ["The glutin contributors, Pierre Krieger <pierre.krieger1708@gmail.com>"]
 description = "Cross-platform OpenGL context provider."
 keywords = ["windowing", "opengl"]


### PR DESCRIPTION
https://github.com/servo/glutin/pull/121 was merged but is still not published in crates.io

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/glutin/124)
<!-- Reviewable:end -->
