### PR TITLE
Implement Android get_dimensions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "servo-glutin"
-version = "0.13.0"
+version = "0.13.1"
 authors = ["The glutin contributors, Pierre Krieger <pierre.krieger1708@gmail.com>"]
 description = "Cross-platform OpenGL context provider."
 keywords = ["windowing", "opengl"]

--- a/src/api/android/mod.rs
+++ b/src/api/android/mod.rs
@@ -64,7 +64,10 @@ impl MonitorId {
 
     #[inline]
     pub fn get_dimensions(&self) -> (u32, u32) {
-        unimplemented!()
+        unsafe {
+            let window = android_glue::get_native_window();
+            (ffi::ANativeWindow_getWidth(window) as u32, ffi::ANativeWindow_getHeight(window) as u32)
+        }
     }
 }
 


### PR DESCRIPTION
At some point Servo started using Glutin `get_dimensions()` method but it's not implemented on Android.

Please, publish the new version to crates.io once this is merged.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/glutin/133)
<!-- Reviewable:end -->
