### PR TITLE
Specify the NSOpenGLPFAAllowOfflineRenderers attribute.

### DIFF
--- a/src/api/cocoa/helpers.rs
+++ b/src/api/cocoa/helpers.rs
@@ -55,6 +55,7 @@ pub fn build_nsattributes<T>(pf_reqs: &PixelFormatRequirements, opengl: &GlAttri
         NSOpenGLPFAAlphaSize as u32, alpha_depth as u32,
         NSOpenGLPFADepthSize as u32, pf_reqs.depth_bits.unwrap_or(24) as u32,
         NSOpenGLPFAStencilSize as u32, pf_reqs.stencil_bits.unwrap_or(8) as u32,
+        NSOpenGLPFAAllowOfflineRenderers as u32,
         NSOpenGLPFAOpenGLProfile as u32, profile,
     ];
 


### PR DESCRIPTION
This commit is cherry-picked from the upstream PR https://github.com/tomaka/glutin/pull/894 .

Without this attribute, on dual-GPU Macs, creating the context will always force a switch to the dedicated GPU. With this attribute, applications can opt in to using the integrated GPU by adding the `NSSupportsAutomaticGraphicsSwitching` key to their app bundle's Info.plist.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/glutin/137)
<!-- Reviewable:end -->
