### PR TITLE
Upgrade core foundation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "servo-glutin"
-version = "0.13.4"
+version = "0.14.0"
 authors = ["The glutin contributors, Pierre Krieger <pierre.krieger1708@gmail.com>"]
 description = "Cross-platform OpenGL context provider."
 keywords = ["windowing", "opengl"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,9 +32,9 @@ objc = "0.2"
 [target.'cfg(target_os = "macos")'.dependencies]
 objc = "0.2"
 cgl = "0.2"
-cocoa = "0.13"
-core-foundation = "0.4"
-core-graphics = "0.12.1"
+cocoa = "0.14"
+core-foundation = "0.5"
+core-graphics = "0.13"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3", features = ["winuser", "winnt", "wingdi", "dwmapi", "shellapi", "windowsx", "libloaderapi", "processthreadsapi"] }

--- a/src/api/cocoa/mod.rs
+++ b/src/api/cocoa/mod.rs
@@ -28,7 +28,7 @@ use cocoa::appkit::NSEventSubtype::*;
 
 use core_foundation::base::TCFType;
 use core_foundation::string::CFString;
-use core_foundation::bundle::{CFBundle, CFBundleGetBundleWithIdentifier};
+use core_foundation::bundle::CFBundleGetBundleWithIdentifier;
 use core_foundation::bundle::{CFBundleGetFunctionPointerForName};
 
 use core_graphics::geometry::{CG_ZERO_POINT, CGRect, CGSize};
@@ -396,14 +396,6 @@ impl Window {
                 None
             } else {
                 app.setActivationPolicy_(activation_policy.into());
-
-                // Set `CFBundleName` appropriately.
-                if let Some(app_name) = app_name {
-                    let info_dictionary = CFBundle::main_bundle().info_dictionary();
-                    info_dictionary.set_value(
-                        NSString::alloc(nil).init_str("CFBundleName") as *const _,
-                        NSString::alloc(nil).init_str(app_name) as *const _);
-                }
 
                 if let Some(icon_path) = icon_path {
                     if let Some(icon_path) = icon_path.to_str() {


### PR DESCRIPTION
This is a PR in a series of PRs originating at https://github.com/servo/core-foundation-rs/pull/132

The plan is to make a breaking change to `core-foundation` and release it as `0.5.0`. But before the merge/publish of `core-foundation` I will prepare a set of PRs making sure the entire dependency graph of Servo is ready for this change and can be switched over to `0.5.0` directly.

TODO before merge:
- [x] Merge `core-foundation`, `core-graphics` and `cocoa` PRs and publish.
- [x] Remove the last commit from this PR, so we depend on code from crates.io.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/glutin/142)
<!-- Reviewable:end -->
