### PR TITLE
Major version bump

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "servo-glutin"
-version = "0.14.3"
+version = "0.15.0"
 authors = ["The glutin contributors, Pierre Krieger <pierre.krieger1708@gmail.com>"]
 description = "Cross-platform OpenGL context provider."
 keywords = ["windowing", "opengl"]


### PR DESCRIPTION
To accommodate the revert of https://github.com/servo/glutin/commit/1887503ba1a1b919c1aeb1e6dfc283540f739b24 per https://github.com/servo/glutin/pull/140#issuecomment-369325726.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/glutin/147)
<!-- Reviewable:end -->
